### PR TITLE
Invalid Salt when signing in

### DIFF
--- a/application/models/user.py
+++ b/application/models/user.py
@@ -16,7 +16,7 @@ class User(db.Model):
 
     @staticmethod
     def hashed_password(password):
-        return bcrypt.generate_password_hash(password)
+        return bcrypt.generate_password_hash(password).decode('utf-8')
 
     @staticmethod
     def get_user_with_email_and_password(email, password):


### PR DESCRIPTION
This is a requirement I have missed about python 3 vs python 2 with the generate_password_hash method which will fix the bug where a sign in after registering causes an internal server error because of an invalid salt