### PR TITLE
Displaying Card History for Current User (Not all players)

### DIFF
--- a/static/src/components/CardHist.js
+++ b/static/src/components/CardHist.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import { Card, CardText, CardHeader, CardMedia, CardTitle, GridList } from 'material-ui';
 
 function CardHist(props) {
-    console.log('==>', props.historyData);
     let cardsPlayed = props.historyData;
     return (
       <div>

--- a/static/src/components/CardHist.js
+++ b/static/src/components/CardHist.js
@@ -1,0 +1,49 @@
+import React, { PropTypes } from 'react';
+import { Card, CardText, CardHeader, CardMedia, CardTitle, GridList } from 'material-ui';
+
+function CardHist(props) {
+    console.log('==>', props.historyData);
+    let cardsPlayed = props.historyData;
+    return (
+      <div>
+        <p><b>All your Cards played</b></p>
+        <div>
+            {cardsPlayed &&
+                cardsPlayed.map((card, index) => {
+                    const imageName = (card.card_name).replace(/\s+/g, '').toLowerCase();
+                    let margin = -20;
+                    if (index === 1) { margin = 0; }
+                    if (index > 0)
+                    {
+                      return (
+                        <Card
+                            className="Card"
+                            data-card-number={index}
+                            key={card.id}
+                            style={{
+                                margin: `${margin}`,
+                                width: 90, display:
+                                'inline-block',
+                                padding: 0 }}
+                        >
+                            <CardMedia>
+                                <img
+                                    alt={`${card.card_name} image`}
+                                    src={`dist/images/cards/${imageName}.png`}
+                                />
+                            </CardMedia>
+                        </Card>
+                    );
+                  }
+                })
+            }
+      </div>
+      </div>
+    );
+}
+
+CardHist.propTypes = {
+    historyData: PropTypes.object.isRequired,
+};
+
+export default CardHist;

--- a/static/src/components/PlayerDisplay.js
+++ b/static/src/components/PlayerDisplay.js
@@ -193,7 +193,7 @@ export class PlayerDisplay extends Component {
                                                 </Table>
                                             </div>
                                         </CardText>
-                                        <CardText id="played cards" expandable={true}>
+                                        <CardText id="played_cards" expandable={true}>
                                             <CardHist historyData={game.history} />
                                         </CardText>
                                     </Card>

--- a/static/src/components/PlayerDisplay.js
+++ b/static/src/components/PlayerDisplay.js
@@ -7,6 +7,7 @@ import { bindActionCreators } from 'redux';
 import * as actions from '../actions/game';
 import Inventory from './Inventory';
 import Wonder from './Wonder';
+import CardHist from './CardHist';
 
 function mapStateToProps(state) {
     return {
@@ -106,6 +107,10 @@ export class PlayerDisplay extends Component {
     		if (boardData.profile) {
     			pName = boardData.profile;									// display profile name if present in returned data
     		}
+        let homeWonder = false;
+        if (boardData.id === this.state.userID) {
+            homeWonder = true;
+        }
 
         return (
             <div>
@@ -152,12 +157,14 @@ export class PlayerDisplay extends Component {
                                                             </TableRowColumn>
                                                             <TableRowColumn>
                                                                 <CardActions>
-                                                                    <FlatButton label="Back to your Wonder" onClick={this.lookUser} />
+                                                                    { !homeWonder ?
+                                                                        <FlatButton label="Back to your Wonder" onClick={this.lookUser} />
+                                                                        :
+                                                                        <FlatButton label="" disabled={true} />
+                                                                    }
                                                                 </CardActions>
-                                                                <CardMedia
-                                                                    overlay={<CardTitle subtitle="Player thinking..." />}
-                                                                >
-                                                                    <img alt="" src={`dist/images/cities/${imageName}A.png`} />
+                                                                <CardMedia>
+                                                                    <img alt="" src={`dist/images/cities/${imageName}B.png`} />
                                                                 </CardMedia>
                                                                 <Wonder data={boardData} />
                                                             </TableRowColumn>
@@ -167,21 +174,18 @@ export class PlayerDisplay extends Component {
                                                                 <List style={ListStyle}>
                                                                     <Inventory item="vp" amount={boardData.points} />
                                                                     <Inventory item="coin" amount={boardData.money} />
-                                                                    <Inventory item="pyramid-stage0" amount={boardData.wonder_level} />
-                                                                    <br />
-                                                                    <Inventory item="military" amount={boardData.military} />
-                                                                    <Inventory item="victoryminus1" amount={boardData.military_loss} />
+                                                                    <Inventory item={`pyramid-stage${boardData.wonder_level}`} amount={boardData.wonder_level} />
                                                                 </List>
                                                             </TableRowColumn>
                                                             <TableRowColumn
                                                                 style={inventorycustomColumnStyle}
                                                             >
                                                                 <List id="buildings" style={ListStyle}>
+                                                                    <Inventory item="military" amount={boardData.military} />
+                                                                    <Inventory item="victoryminus1" amount={boardData.military_loss} />
                                                                     <Inventory item="cog" amount={boardData.cog} />
                                                                     <Inventory item="tablet" amount={boardData.tablet} />
                                                                     <Inventory item="compass" amount={boardData.compass} />
-                                                                    <Inventory item="commercial" amount={0} />
-                                                                    <Inventory item="civilian" amount={0} />
                                                                 </List>
                                                             </TableRowColumn>
                                                         </TableRow>
@@ -190,13 +194,8 @@ export class PlayerDisplay extends Component {
                                             </div>
                                         </CardText>
                                         <CardText id="played cards" expandable={true}>
-                                            <hr />
-                                            <h3>All Cards Played for Wonder</h3>
-                                            <p><i>
-                                                Card 1, Card 2...
-                                            </i></p>
+                                            <CardHist historyData={game.history} />
                                         </CardText>
-
                                     </Card>
                                   </TableRowColumn>
                                   <TableRowColumn width="50" id="rightNav" >


### PR DESCRIPTION
Changed PlayerDisplay drop down to call new module
Created CardHist.js to cycle through all cards
Smaller card images, and overlapping to fit all in one line (create a slightly different card list feel than Cards in hand list.
- No title or descriptions, just images