### PR TITLE
Reduce White space at top

### DIFF
--- a/static/src/components/GameScreen.js
+++ b/static/src/components/GameScreen.js
@@ -259,9 +259,6 @@ export class GameScreen extends Component {
                                     />
                                 }
                             </div>
-                            <h3 style={{ marginLeft: 100 }}>
-                                <b>Age {game.game.age}, Round {game.game.round}: Cards in Hand</b>
-                            </h3>
                             <center>
                             {game.cards && game.cards[0].name &&
                                 game.cards.map((card, index) => {

--- a/static/src/components/Play.js
+++ b/static/src/components/Play.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { RaisedButton, Dialog, FlatButton, Paper, Checkbox, Avatar, Chip } from 'material-ui';
+import { RaisedButton, Dialog, FlatButton, Paper, Checkbox } from 'material-ui';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory } from 'react-router';

--- a/static/src/components/Play.js
+++ b/static/src/components/Play.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { RaisedButton, Dialog, FlatButton, Paper, Checkbox } from 'material-ui';
+import { RaisedButton, Dialog, FlatButton, Paper, Checkbox, Avatar, Chip } from 'material-ui';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory } from 'react-router';
@@ -191,7 +191,7 @@ export class Play extends React.Component {
         ];
 
         return (
-            <div className="Game col-md-12">
+            <div className="Game col-md-12" style={{ padding: 0 }}>
                 {error &&
                     <p>There was an error</p>
                 }
@@ -226,17 +226,28 @@ export class Play extends React.Component {
                         </div>
                     </div>
                 }
-                {game &&
-                    <RaisedButton
-                        label="End Game"
-                        primary={primary}
-                        style={{
-                            float: 'right',
-                            display: 'block',
-                            margin: '0 0 20px 0',
-                        }}
-                        onClick={() => this.endGameDialog()}
-                    />
+                {game && this.props.game &&
+                    <div>
+                        <div style={{ float: 'left', marginRight: 0, paddingTop: 0, paddingLeft: 50, width: '20%' }}>
+                            <h3 style={{ marginTop: 0 }}>
+                                <b>Age: {this.props.game.game.age} -
+                                Round: {this.props.game.game.round}
+                                </b>
+                            </h3>
+                        </div>
+                        <div style={{ float: 'left', marginRight: 0, paddingTop: 0, width: '60%' }}>
+                            <center><h3 style={{ marginTop: 0 }}> Cards in Hand </h3></center>
+                        </div>
+                        <RaisedButton
+                            label="End Game"
+                            primary={primary}
+                            style={{
+                                float: 'right',
+                                margin: '0 0 20px 0',
+                            }}
+                            onClick={() => this.endGameDialog()}
+                        />
+                    </div>
                 }
                 {game &&
                     <div style={{ clear: 'both' }}>
@@ -260,6 +271,7 @@ export class Play extends React.Component {
 
 Play.propTypes = {
     endGame: PropTypes.func.isRequired,
+    game: PropTypes.object,
 };
 
 export default connect(

--- a/static/src/containers/App/index.js
+++ b/static/src/containers/App/index.js
@@ -21,8 +21,8 @@ class App extends React.Component { // eslint-disable-line react/prefer-stateles
                 <section>
                     <Header />
                     <div
-                      className="container"
-                      style={{ marginTop: 10, paddingBottom: 250 }}
+                      className="container-fluid"
+                      style={{ marginTop: 10, padding: 2 }}
                     >
                         {this.props.children}
                     </div>


### PR DESCRIPTION
Expanded total usable browser space
Used play.js to display age/rounds in same line as the 'End Game' button - All inside one <div>
End Game button remains where it is, but fully over to RHS now.