### PR TITLE
Fixing failing test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,11 @@ dependencies:
         - pip install -r requirements.txt
 
 test:
-    override:
+    post:
         - mkdir -p $CIRCLE_TEST_REPORTS/reports:
             parallel: true
         - python test.py --junit-xml=coverage.xml --cov=application/ tests/:
             parallel: true
-    post:
         - mv coverage.xml $CIRCLE_TEST_REPORTS/reports/coverage.xml
         - npm run test:coveralls
         - cat static/coverage/lcov.info | static/node_modules/coveralls/bin/coveralls.js

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,6 @@ from application.utils import auth
 from application.controllers.database_functions import *
 from index import app
 
-
 class TestAPI(BaseTestConfig):
     some_user = {
         "email": "one@gmail.com",
@@ -63,7 +62,7 @@ class TestAPI(BaseTestConfig):
                 content_type='application/json'
         )
 
-        self.assertEqual(res3.status_code, 403)
+        self.assertEqual(res3.status_code, 401)
 
         res4 = self.app.post(
                 "/api/get_token",


### PR DESCRIPTION
- Since i wrapped the is_token_valid in require_auth to ensure if the user doesn't exist it redirects to the login/register screen this has broken an integration test. Fixing this to ensure if a fake user is passed the api returns 401 not authorised

- Also move python tests to the test post parameter in circleci as the override appears to continue the build if a test fails